### PR TITLE
fix: (dirty) workaround for autodocs in for WDS & Rollup build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4834,6 +4834,25 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.0.1.tgz",
+      "integrity": "sha512-RgVfl5hWMkxN1h/uZj8FVESvPuBJ/uf6ly6GTj0GONnkfoBN5KC0MSz+PN2OLDgYXMhtG0mWpTrkiOjoxAIevw==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
@@ -17681,7 +17700,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
       "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "*"
       }
@@ -26401,6 +26419,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/rollup-plugin-inject-process-env": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject-process-env/-/rollup-plugin-inject-process-env-1.3.1.tgz",
+      "integrity": "sha512-kKDoL30IZr0wxbNVJjq+OS92RJSKRbKV6B5eNW4q3mZTFqoWDh6lHy+mPDYuuGuERFNKXkG+AKxvYqC9+DRpKQ==",
+      "dependencies": {
+        "magic-string": "^0.25.7"
+      }
+    },
+    "node_modules/rollup-plugin-inject-process-env/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/rollup-plugin-postcss": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz",
@@ -33430,6 +33464,9 @@
       "license": "MIT",
       "dependencies": {
         "@chialab/esbuild-plugin-commonjs": "^0.17.2",
+        "@rollup/plugin-alias": "^5.0.1",
+        "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-json": "^6.0.1",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/pluginutils": "^5.0.2",
         "@storybook/core-common": "^7.0.0",
@@ -33449,6 +33486,7 @@
         "path-browserify": "^1.0.1",
         "rollup": "^3.25.1",
         "rollup-plugin-external-globals": "^0.7.3",
+        "rollup-plugin-inject-process-env": "^1.3.1",
         "slash": "^5.1.0"
       },
       "devDependencies": {
@@ -33467,6 +33505,60 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "packages/storybook-builder/node_modules/@rollup/plugin-alias": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.0.1.tgz",
+      "integrity": "sha512-JObvbWdOHoMy9W7SU0lvGhDtWq9PllP5mjpAy+TUslZG/WzOId9u80Hsqq1vCUn9pFJ0cxpdcnAv+QzU2zFH3Q==",
+      "dependencies": {
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/storybook-builder/node_modules/@rollup/plugin-alias/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/storybook-builder/node_modules/@rollup/plugin-commonjs": {
+      "version": "25.0.7",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+      "integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "packages/storybook-builder/node_modules/fs-extra": {
@@ -33491,6 +33583,17 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/storybook-builder/node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/storybook-builder/node_modules/slash": {

--- a/packages/storybook-builder/package.json
+++ b/packages/storybook-builder/package.json
@@ -48,6 +48,9 @@
   ],
   "dependencies": {
     "@chialab/esbuild-plugin-commonjs": "^0.17.2",
+    "@rollup/plugin-alias": "^5.0.1",
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-json": "^6.0.1",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/pluginutils": "^5.0.2",
     "@storybook/core-common": "^7.0.0",
@@ -67,6 +70,7 @@
     "path-browserify": "^1.0.1",
     "rollup": "^3.25.1",
     "rollup-plugin-external-globals": "^0.7.3",
+    "rollup-plugin-inject-process-env": "^1.3.1",
     "slash": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/storybook-builder/src/index.ts
+++ b/packages/storybook-builder/src/index.ts
@@ -20,6 +20,10 @@ import {
   rollupPluginPrebundleModules,
 } from './rollup-plugin-prebundle-modules';
 import { rollupPluginStorybookBuilder } from './rollup-plugin-storybook-builder';
+import rollupPluginCommonjs from '@rollup/plugin-commonjs';
+import rollupPluginInjectProcessEnv from 'rollup-plugin-inject-process-env';
+import rollupPluginJson from '@rollup/plugin-json';
+import alias from '@rollup/plugin-alias';
 
 const wdsPluginExternalGlobals = fromRollup(rollupPluginExternalGlobals);
 const wdsPluginPrebundleModules = fromRollup(rollupPluginPrebundleModules);
@@ -144,7 +148,14 @@ export const build: WdsBuilder['build'] = async ({ startTime, options }) => {
         extractAssets: false,
       }),
       rollupPluginNodeResolve(),
-      rollupPluginPrebundleModules(env),
+      alias({
+        entries: [
+          { find: 'assert', replacement: 'browser-assert' },
+        ]
+      }),
+      rollupPluginJson(),
+      rollupPluginCommonjs(),
+      rollupPluginInjectProcessEnv(env),
       rollupPluginStorybookBuilder(options),
       rollupPluginExternalGlobals(globals),
     ],

--- a/packages/storybook-builder/src/rollup-plugin-prebundle-modules.ts
+++ b/packages/storybook-builder/src/rollup-plugin-prebundle-modules.ts
@@ -85,4 +85,37 @@ export const CANDIDATES = [
 
   // ESM, but uses `process.env.NODE_ENV`
   'tiny-invariant',
+  /**
+     * dependency of '@storybook/react-dom-shim' (https://cdn.jsdelivr.net/npm/@storybook/react-dom-shim@7.5.1/dist/react-16.mjs)
+     * exports rely on commonjs: https://cdn.jsdelivr.net/npm/react-dom@18.2.0/index.js
+     */ 
+  'react-dom',
+  /**
+   * dependency of '@storybook/theming' (https://cdn.jsdelivr.net/npm/@storybook/theming@7.5.1/dist/index.mjs) 
+   * `import * as React from 'react';
+   * import { forwardRef, useContext } from 'react';`
+   * exports rely on commonjs: https://cdn.jsdelivr.net/npm/react@18.2.0/index.js
+   */
+  'react',
+  /**
+   * dependency of '@storybook/theming' (https://cdn.jsdelivr.net/npm/@storybook/theming@7.5.1/dist/index.mjs)
+   * `import memoize2 from 'memoizerific';`
+   * exports rely on commonjs: https://cdn.jsdelivr.net/npm/memoizerific@1.11.3/src/memoizerific.js
+   */
+  'memoizerific',
+  /**
+   * dependencies of '@storybook/blocks' (https://cdn.jsdelivr.net/npm/@storybook/blocks@7.5.1/dist/index.mjs)
+   * they all rely on commonjs (https://cdn.jsdelivr.net/npm/lodash@4.17.21/uniq.js for instance)
+   */
+  'lodash/uniq.js',
+  'lodash/pickBy.js',
+  'lodash/cloneDeep.js',
+  'lodash/throttle.js',
+  /**
+   * dependency of '@storybook/dist/Color-[hash].msj' (https://cdn.jsdelivr.net/npm/@storybook/blocks@7.5.1/dist/Color-6VNJS4EI.mjs)
+   * exports rely on commonjs: https://cdn.jsdelivr.net/npm/color-convert@2.0.1/index.js 
+   */
+  'color-convert',
+  'tocbot',
+  '@storybook/blocks',
 ];


### PR DESCRIPTION
This is not an actual Pull Request.

The goal is only to show the diff to make my modifications more obvious in case they can help solve the issue.

The workaround I used does not seem to be good because I don't filter what the `commonjs` processes.
Even though it does solve my issues, it may cause performance issues since `commonjs` is a slow plugin?
